### PR TITLE
Add cross-platform build Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+BINARY=companion
+PLATFORMS=windows/amd64 linux/amd64 linux/arm64 freebsd/amd64 darwin/amd64 darwin/arm64
+
+.PHONY: build cross clean
+
+build:
+	go build -o $(BINARY) ./cmd/companion
+
+cross:
+	@for platform in $(PLATFORMS); do \
+		os=$${platform%/*}; \
+		arch=$${platform##*/}; \
+		output=$(BINARY)-$$os-$$arch; \
+		if [ $$os = windows ]; then output=$$output.exe; fi; \
+		echo "Building $$output"; \
+		GOOS=$$os GOARCH=$$arch go build -o $$output ./cmd/companion || exit $$?; \
+	done
+
+clean:
+	rm -f $(BINARY) $(BINARY)-* 2>/dev/null || true


### PR DESCRIPTION
## Summary
- add Makefile that builds the companion binary and supports cross-compiling to windows-amd64, linux-amd64, linux-arm64, freebsd-amd64, darwin-amd64, and darwin-arm64

## Testing
- `go test ./...`
- `make`
- `make cross`


------
https://chatgpt.com/codex/tasks/task_e_68b908d1c4708326ba5587673da7d4dd