### PR TITLE
Remove obsolete Codex submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "codex"]
-	path = codex
-	url = https://github.com/openai/codex.git

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -29,8 +29,6 @@ internal/
     static/          # embedded HTML templates and JS
   log/
     store.go         # persistence for request logs
-external/
-  codex/             # reference checkout of https://github.com/openai/codex (not vendored)
 ```
 
 ## Implementation Steps
@@ -103,8 +101,7 @@ external/
    - REST endpoints under `/admin/api` implement JSON input/output.
 
 7. **Codex API Reference**
-   - Maintain a local checkout of <https://github.com/openai/codex> under `external/codex` for reference implementations of API calls and login flows.
-   - The proxy mirrors its REST endpoints and request formats but does not vendor any of the repository's code.
+   - The proxy mirrors Codex's REST endpoints and request formats but does not vendor any of the upstream repository's code.
 
 ### Codex `auth.json` format
 


### PR DESCRIPTION
## Summary
- remove unused codex submodule and drop .gitmodules
- update design docs to remove references to the external checkout

## Testing
- `go test ./...` *(fails: command terminated due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68b90f0ad184832688ca22d6489568a5