### PR TITLE
build: name binary codex-companion with Windows exe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
-BINARY=companion
+BINARY_NAME=codex-companion
 PLATFORMS=windows/amd64 linux/amd64 linux/arm64 freebsd/amd64 darwin/amd64 darwin/arm64
+
+GOOS := $(shell go env GOOS)
+EXT :=
+ifeq ($(GOOS),windows)
+	EXT := .exe
+endif
+BINARY=$(BINARY_NAME)$(EXT)
 
 .PHONY: build cross clean
 
@@ -10,11 +17,11 @@ cross:
 	@for platform in $(PLATFORMS); do \
 		os=$${platform%/*}; \
 		arch=$${platform##*/}; \
-		output=$(BINARY)-$$os-$$arch; \
+		output=$(BINARY_NAME)-$$os-$$arch; \
 		if [ $$os = windows ]; then output=$$output.exe; fi; \
 		echo "Building $$output"; \
 		GOOS=$$os GOARCH=$$arch go build -o $$output ./cmd/companion || exit $$?; \
 	done
 
 clean:
-	rm -f $(BINARY) $(BINARY)-* 2>/dev/null || true
+	rm -f $(BINARY_NAME) $(BINARY_NAME).exe $(BINARY_NAME)-* 2>/dev/null || true


### PR DESCRIPTION
## Summary
- rename build output to `codex-companion`
- append `.exe` extension for Windows builds

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b91425a36083268a282004df1f8e01