### PR TITLE
Split admin pages and improve account handling

### DIFF
--- a/internal/account/manager_test.go
+++ b/internal/account/manager_test.go
@@ -3,6 +3,7 @@ package account
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -81,6 +82,26 @@ func TestListOrderUpdateDelete(t *testing.T) {
 	gone, err := mgr.Get(ctx, a1.ID)
 	if err != nil || gone != nil {
 		t.Fatalf("delete not effective: %v %v", gone, err)
+	}
+}
+
+func TestDuplicate(t *testing.T) {
+	db := setupTestDB(t)
+	mgr, _ := NewManager(db)
+	ctx := context.Background()
+
+	if _, err := mgr.AddAPIKey(ctx, "a1", "k1", 0); err != nil {
+		t.Fatalf("add api: %v", err)
+	}
+	if _, err := mgr.AddAPIKey(ctx, "a2", "k1", 0); !errors.Is(err, ErrDuplicate) {
+		t.Fatalf("expected duplicate api key error, got %v", err)
+	}
+
+	if _, err := mgr.AddChatGPT(ctx, "c1", "rt1", 0); err != nil {
+		t.Fatalf("add chatgpt: %v", err)
+	}
+	if _, err := mgr.AddChatGPT(ctx, "c2", "rt1", 0); !errors.Is(err, ErrDuplicate) {
+		t.Fatalf("expected duplicate chatgpt error, got %v", err)
 	}
 }
 

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -48,7 +49,8 @@ func TestExchangeRefreshTokenError(t *testing.T) {
 }
 
 func setupAuthTestMgr(t *testing.T) (*account.Manager, *account.Account) {
-	db, err := sql.Open("sqlite", "file:auth?mode=memory&cache=shared")
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -17,7 +18,8 @@ import (
 
 func setupProxy(t *testing.T, upstream http.HandlerFunc) (*Handler, *account.Manager, *logpkg.Store) {
 	t.Helper()
-	db, err := sql.Open("sqlite", "file:proxy?mode=memory&cache=shared")
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/webui/handler.go
+++ b/internal/webui/handler.go
@@ -65,8 +65,12 @@ func AdminHandler(am *account.Manager, ls *logpkg.Store) http.Handler {
 				return
 			}
 			if err != nil {
-				logger.Errorf("add account failed: %v", err)
-				http.Error(w, err.Error(), http.StatusInternalServerError)
+				if errors.Is(err, account.ErrDuplicate) {
+					http.Error(w, err.Error(), http.StatusConflict)
+				} else {
+					logger.Errorf("add account failed: %v", err)
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
 				return
 			}
 			json.NewEncoder(w).Encode(a)

--- a/internal/webui/handler_test.go
+++ b/internal/webui/handler_test.go
@@ -103,6 +103,14 @@ func TestAccountsAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// duplicate API key should be rejected
+	req = httptest.NewRequest(http.MethodPost, "/admin/api/accounts", strings.NewReader(body))
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected conflict for duplicate api key, got %d", rec.Code)
+	}
+
 	a.Name = "new"
 	buf, _ := json.Marshal(&a)
 	req = httptest.NewRequest(http.MethodPut, "/admin/api/accounts/"+strconv.FormatInt(a.ID, 10), bytes.NewReader(buf))

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -6,6 +6,7 @@
 </head>
 <body>
 <h1>Codex Companion</h1>
+<nav><a href="index.html">Accounts</a> | <a href="logs.html">Logs</a></nav>
 
 <section>
   <h2>Add API Key Account</h2>
@@ -28,12 +29,12 @@
 
 <section>
   <h2>Accounts</h2>
-  <div id="accounts"></div>
-</section>
-
-<section>
-  <h2>Logs</h2>
-  <pre id="logs"></pre>
+  <table id="accounts">
+    <thead>
+      <tr><th>ID</th><th>Type</th><th>Name</th><th>Identifier</th><th>Priority</th><th>Actions</th></tr>
+    </thead>
+    <tbody></tbody>
+  </table>
 </section>
 
 <script>
@@ -41,33 +42,30 @@ async function loadAccounts() {
   try {
     const res = await fetch('/admin/api/accounts');
     const accounts = await res.json();
-    console.debug('Loaded accounts', accounts);
-    const container = document.getElementById('accounts');
-    container.innerHTML = '';
+    const tbody = document.querySelector('#accounts tbody');
+    tbody.innerHTML = '';
     accounts.forEach(a => {
-      const div = document.createElement('div');
-      div.textContent = `${a.id}: ${a.name} (priority ${a.priority})`;
+      const tr = document.createElement('tr');
+      const type = a.type === 0 ? 'API Key' : 'ChatGPT';
+      const ident = a.type === 0 ? a.api_key : a.refresh_token;
+      tr.innerHTML = `<td>${a.id}</td><td>${type}</td><td>${a.name}</td><td>${ident}</td><td>${a.priority}</td>`;
+      const actions = document.createElement('td');
       const del = document.createElement('button');
       del.textContent = 'Delete';
       del.onclick = async () => {
         const resp = await fetch(`/admin/api/accounts/${a.id}`, {method: 'DELETE'});
         if (!resp.ok) {
-          console.error('Delete failed', resp.status);
+          alert('Delete failed ' + resp.status);
         }
         loadAccounts();
       };
-      div.appendChild(del);
-      container.appendChild(div);
+      actions.appendChild(del);
+      tr.appendChild(actions);
+      tbody.appendChild(tr);
     });
   } catch (e) {
     console.error('Load accounts error', e);
   }
-}
-
-async function loadLogs() {
-  const res = await fetch('/admin/api/logs');
-  const logs = await res.json();
-  document.getElementById('logs').textContent = JSON.stringify(logs, null, 2);
 }
 
 document.getElementById('apiKeyForm').onsubmit = async (e) => {
@@ -85,7 +83,7 @@ document.getElementById('apiKeyForm').onsubmit = async (e) => {
       })
     });
     if (!resp.ok) {
-      console.error('Add API key account failed', resp.status);
+      alert('Add API key account failed: ' + (await resp.text()));
     }
   } catch (e) {
     console.error('Add API key account error', e);
@@ -109,7 +107,7 @@ document.getElementById('chatgptForm').onsubmit = async (e) => {
       })
     });
     if (!resp.ok) {
-      console.error('Add ChatGPT account failed', resp.status);
+      alert('Add ChatGPT account failed: ' + (await resp.text()));
     }
   } catch (e) {
     console.error('Add ChatGPT account error', e);
@@ -132,7 +130,6 @@ document.getElementById('importBtn').onclick = async () => {
 
 function load() {
   loadAccounts();
-  loadLogs();
 }
 
 load();

--- a/internal/webui/static/logs.html
+++ b/internal/webui/static/logs.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Logs - Codex Companion</title>
+</head>
+<body>
+<h1>Logs</h1>
+<nav><a href="index.html">Accounts</a> | <a href="logs.html">Logs</a></nav>
+<table id="logs">
+  <thead>
+    <tr><th>ID</th><th>Time</th><th>Account</th><th>Method</th><th>URL</th><th>Status</th><th>Error</th><th>Details</th></tr>
+  </thead>
+  <tbody></tbody>
+</table>
+<dialog id="logModal">
+  <pre id="logDetail"></pre>
+  <button id="closeModal">Close</button>
+</dialog>
+<script>
+async function loadLogs() {
+  const res = await fetch('/admin/api/logs');
+  const logs = await res.json();
+  const tbody = document.querySelector('#logs tbody');
+  tbody.innerHTML = '';
+  logs.forEach(l => {
+    const tr = document.createElement('tr');
+    const time = new Date(l.Time).toLocaleString();
+    tr.innerHTML = `<td>${l.ID}</td><td>${time}</td><td>${l.AccountID}</td><td>${l.Method}</td><td>${l.URL}</td><td>${l.Status}</td><td>${l.Error || ''}</td>`;
+    const td = document.createElement('td');
+    const btn = document.createElement('button');
+    btn.textContent = 'Details';
+    btn.onclick = () => {
+      document.getElementById('logDetail').textContent = JSON.stringify(l, null, 2);
+      document.getElementById('logModal').showModal();
+    };
+    td.appendChild(btn);
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+  });
+}
+
+document.getElementById('closeModal').onclick = () => document.getElementById('logModal').close();
+loadLogs();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Separate account and log management into dedicated pages
- Display logs in a table with modal for detailed request info
- Show detailed account info and prevent duplicate accounts

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b9153d2bc083268f4f27ce1dc50b3d