### PR TITLE
feat: restrict codex paths and allow custom base URL

### DIFF
--- a/cmd/companion/main.go
+++ b/cmd/companion/main.go
@@ -37,7 +37,7 @@ func main() {
 	sched.StartReactivator(ctx, time.Minute)
 
 	adminHandler := webui.AdminHandler(am, ls)
-	proxyHandler := proxy.New(sched, ls, "https://api.openai.com")
+	proxyHandler := proxy.New(sched, ls, "https://api.openai.com", "https://chatgpt.com/backend-api/codex")
 
 	mux := http.NewServeMux()
 	mux.Handle("/admin/", adminHandler)

--- a/internal/account/manager_test.go
+++ b/internal/account/manager_test.go
@@ -28,7 +28,7 @@ func TestAddAndGet(t *testing.T) {
 		t.Fatalf("new manager: %v", err)
 	}
 	ctx := context.Background()
-	a1, err := mgr.AddAPIKey(ctx, "a1", "k1", 1)
+	a1, err := mgr.AddAPIKey(ctx, "a1", "k1", "", 1)
 	if err != nil {
 		t.Fatalf("add api: %v", err)
 	}
@@ -57,8 +57,8 @@ func TestListOrderUpdateDelete(t *testing.T) {
 	db := setupTestDB(t)
 	mgr, _ := NewManager(db)
 	ctx := context.Background()
-	a1, _ := mgr.AddAPIKey(ctx, "a1", "k1", 2)
-	a2, _ := mgr.AddAPIKey(ctx, "a2", "k2", 1)
+	a1, _ := mgr.AddAPIKey(ctx, "a1", "k1", "", 2)
+	a2, _ := mgr.AddAPIKey(ctx, "a2", "k2", "", 1)
 	list, err := mgr.List(ctx)
 	if err != nil {
 		t.Fatalf("list: %v", err)
@@ -90,10 +90,10 @@ func TestDuplicate(t *testing.T) {
 	mgr, _ := NewManager(db)
 	ctx := context.Background()
 
-	if _, err := mgr.AddAPIKey(ctx, "a1", "k1", 0); err != nil {
+	if _, err := mgr.AddAPIKey(ctx, "a1", "k1", "", 0); err != nil {
 		t.Fatalf("add api: %v", err)
 	}
-	if _, err := mgr.AddAPIKey(ctx, "a2", "k1", 0); !errors.Is(err, ErrDuplicate) {
+	if _, err := mgr.AddAPIKey(ctx, "a2", "k1", "", 0); !errors.Is(err, ErrDuplicate) {
 		t.Fatalf("expected duplicate api key error, got %v", err)
 	}
 
@@ -109,7 +109,7 @@ func TestExhaustReactivate(t *testing.T) {
 	db := setupTestDB(t)
 	mgr, _ := NewManager(db)
 	ctx := context.Background()
-	a, _ := mgr.AddAPIKey(ctx, "a", "k", 1)
+	a, _ := mgr.AddAPIKey(ctx, "a", "k", "", 1)
 	reset := time.Now().Add(time.Hour)
 	if err := mgr.MarkExhausted(ctx, a.ID, reset); err != nil {
 		t.Fatalf("mark: %v", err)

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -107,7 +107,7 @@ func TestRefreshAPIKey(t *testing.T) {
 	db, _ := sql.Open("sqlite", "file:auth2?mode=memory&cache=shared")
 	mgr, _ := account.NewManager(db)
 	ctx := context.Background()
-	a, _ := mgr.AddAPIKey(ctx, "a", "k", 1)
+	a, _ := mgr.AddAPIKey(ctx, "a", "k", "", 1)
 	defer swapClient(roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		t.Fatalf("should not call")
 		return nil, nil

--- a/internal/webui/handler.go
+++ b/internal/webui/handler.go
@@ -44,6 +44,7 @@ func AdminHandler(am *account.Manager, ls *logpkg.Store) http.Handler {
 				Type         string `json:"type"`
 				Name         string `json:"name"`
 				APIKey       string `json:"api_key"`
+				BaseURL      string `json:"base_url"`
 				RefreshToken string `json:"refresh_token"`
 				AccountID    string `json:"account_id"`
 				Priority     int    `json:"priority"`
@@ -56,7 +57,7 @@ func AdminHandler(am *account.Manager, ls *logpkg.Store) http.Handler {
 			var a *account.Account
 			var err error
 			if req.Type == "api_key" {
-				a, err = am.AddAPIKey(ctx, req.Name, req.APIKey, req.Priority)
+				a, err = am.AddAPIKey(ctx, req.Name, req.APIKey, req.BaseURL, req.Priority)
 			} else if req.Type == "chatgpt" {
 				a, err = am.AddChatGPT(ctx, req.Name, req.RefreshToken, req.AccountID, req.Priority)
 			} else {


### PR DESCRIPTION
## Summary
- only forward Codex API paths `/v1/responses`, `/v1/chat/completions`, and `/v1/models`
- support per-API-key `BaseURL` overriding default upstream
- forward ChatGPT accounts to `https://chatgpt.com/backend-api/codex` and strip `/v1` prefix
- document new behavior in DESIGN

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b91f35600c8326ae0d33b7cc2701d5