### PR TITLE
Log request/response bodies as plain text

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -163,9 +163,9 @@ type RequestLog struct {
     Method     string
     URL        string
     ReqHeader  http.Header
-    ReqBody    []byte
+    ReqBody    string
     RespHeader http.Header
-    RespBody   []byte
+    RespBody   string
     Status     int
     Error      string
 }

--- a/internal/log/store.go
+++ b/internal/log/store.go
@@ -16,9 +16,9 @@ type RequestLog struct {
 	Method     string
 	URL        string
 	ReqHeader  http.Header
-	ReqBody    []byte
+	ReqBody    string
 	RespHeader http.Header
-	RespBody   []byte
+	RespBody   string
 	Status     int
 	Error      string
 }
@@ -45,9 +45,9 @@ func (s *Store) init() error {
         method TEXT,
         url TEXT,
         req_header BLOB,
-        req_body BLOB,
-        resp_header BLOB,
-        resp_body BLOB,
+       req_body TEXT,
+       resp_header BLOB,
+       resp_body TEXT,
         status INTEGER,
         error TEXT
     )`

--- a/internal/log/store_test.go
+++ b/internal/log/store_test.go
@@ -33,9 +33,9 @@ func TestInsertList(t *testing.T) {
 		Method:     "GET",
 		URL:        "u1",
 		ReqHeader:  http.Header{"A": {"1"}},
-		ReqBody:    []byte("req1"),
+		ReqBody:    "req1",
 		RespHeader: http.Header{"X": {"1"}},
-		RespBody:   []byte("resp1"),
+		RespBody:   "resp1",
 		Status:     200,
 	}
 	rl2 := &RequestLog{
@@ -44,9 +44,9 @@ func TestInsertList(t *testing.T) {
 		Method:     "POST",
 		URL:        "u2",
 		ReqHeader:  http.Header{"B": {"2"}},
-		ReqBody:    []byte("req2"),
+		ReqBody:    "req2",
 		RespHeader: http.Header{"Y": {"2"}},
-		RespBody:   []byte("resp2"),
+		RespBody:   "resp2",
 		Status:     500,
 	}
 	rl3 := &RequestLog{
@@ -55,9 +55,9 @@ func TestInsertList(t *testing.T) {
 		Method:     "DELETE",
 		URL:        "u3",
 		ReqHeader:  http.Header{"C": {"3"}},
-		ReqBody:    []byte("req3"),
+		ReqBody:    "req3",
 		RespHeader: http.Header{"Z": {"3"}},
-		RespBody:   []byte("resp3"),
+		RespBody:   "resp3",
 		Status:     201,
 	}
 	for i, rl := range []*RequestLog{rl1, rl2, rl3} {
@@ -72,7 +72,7 @@ func TestInsertList(t *testing.T) {
 	if len(logs) != 2 || logs[0].ID <= logs[1].ID {
 		t.Fatalf("unexpected order: %+v", logs)
 	}
-	if logs[0].ReqHeader.Get("C") != "3" || string(logs[0].ReqBody) != "req3" || logs[0].RespHeader.Get("Z") != "3" || string(logs[0].RespBody) != "resp3" {
+	if logs[0].ReqHeader.Get("C") != "3" || logs[0].ReqBody != "req3" || logs[0].RespHeader.Get("Z") != "3" || logs[0].RespBody != "resp3" {
 		t.Fatalf("log fields not restored: %+v", logs[0])
 	}
 }

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -96,7 +96,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				Method:    r.Method,
 				URL:       r.URL.String(),
 				ReqHeader: r.Header.Clone(),
-				ReqBody:   reqBody,
+				ReqBody:   string(reqBody),
 				Error:     err.Error(),
 			})
 			if attempts == 2 {
@@ -115,9 +115,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Method:     r.Method,
 			URL:        r.URL.String(),
 			ReqHeader:  r.Header.Clone(),
-			ReqBody:    reqBody,
+			ReqBody:    string(reqBody),
 			RespHeader: resp.Header.Clone(),
-			RespBody:   respBody,
+			RespBody:   string(respBody),
 			Status:     resp.StatusCode,
 		})
 


### PR DESCRIPTION
## Summary
- store request and response bodies as strings instead of bytes
- update log schema to use TEXT for req/resp bodies
- log proxy request/response bodies without base64 encoding

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b9259c17e08326ae92f38fc7abe51f