### PR TITLE
feat: reorder accounts and paginate logs

### DIFF
--- a/internal/log/store.go
+++ b/internal/log/store.go
@@ -64,9 +64,9 @@ func (s *Store) Insert(ctx context.Context, rl *RequestLog) error {
 	return err
 }
 
-// List returns latest logs limited by n.
-func (s *Store) List(ctx context.Context, n int) ([]*RequestLog, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, time, account_id, method, url, req_header, req_body, resp_header, resp_body, status, error FROM logs ORDER BY id DESC LIMIT ?`, n)
+// List returns latest logs limited by n with offset.
+func (s *Store) List(ctx context.Context, n, offset int) ([]*RequestLog, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, time, account_id, method, url, req_header, req_body, resp_header, resp_body, status, error FROM logs ORDER BY id DESC LIMIT ? OFFSET ?`, n, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/log/store_test.go
+++ b/internal/log/store_test.go
@@ -65,7 +65,7 @@ func TestInsertList(t *testing.T) {
 			t.Fatalf("insert %d: %v", i+1, err)
 		}
 	}
-	logs, err := s.List(ctx, 2)
+	logs, err := s.List(ctx, 2, 0)
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
@@ -74,5 +74,11 @@ func TestInsertList(t *testing.T) {
 	}
 	if logs[0].ReqHeader.Get("C") != "3" || logs[0].ReqBody != "req3" || logs[0].RespHeader.Get("Z") != "3" || logs[0].RespBody != "resp3" {
 		t.Fatalf("log fields not restored: %+v", logs[0])
+	}
+
+	// test offset
+	logs, err = s.List(ctx, 1, 1)
+	if err != nil || len(logs) != 1 || logs[0].ID == rl3.ID {
+		t.Fatalf("offset failed: %+v %v", logs, err)
 	}
 }

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -56,7 +56,7 @@ func TestServeHTTPForwardAndLog(t *testing.T) {
 	if rec.Code != 200 || rec.Body.String() != "ok" {
 		t.Fatalf("bad resp %d %s", rec.Code, rec.Body.String())
 	}
-	logs, err := ls.List(ctx, 10)
+	logs, err := ls.List(ctx, 10, 0)
 	if err != nil || len(logs) != 1 || logs[0].Status != 200 {
 		t.Fatalf("logs %v %v", logs, err)
 	}

--- a/internal/webui/handler_test.go
+++ b/internal/webui/handler_test.go
@@ -83,7 +83,7 @@ func TestImportAuth(t *testing.T) {
 func TestAccountsAPI(t *testing.T) {
 	mgr, _, h := setupWebUI(t)
 
-	body := `{"type":"chatgpt","name":"cg","refresh_token":"rt","priority":2}`
+	body := `{"type":"chatgpt","name":"cg","refresh_token":"rt"}`
 	req := httptest.NewRequest(http.MethodPost, "/admin/api/accounts", strings.NewReader(body))
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -91,7 +91,7 @@ func TestAccountsAPI(t *testing.T) {
 		t.Fatalf("post chatgpt: %d", rec.Code)
 	}
 
-	body = `{"type":"api_key","name":"ak","api_key":"k","priority":1}`
+	body = `{"type":"api_key","name":"ak","api_key":"k"}`
 	req = httptest.NewRequest(http.MethodPost, "/admin/api/accounts", strings.NewReader(body))
 	rec = httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -130,7 +130,7 @@ func TestAccountsAPI(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&list); err != nil || len(list) != 2 {
 		t.Fatalf("list decode: %v %v", err, list)
 	}
-	if list[0].Name != "new" || list[1].Name != "cg" {
+	if list[0].Name != "cg" || list[1].Name != "new" {
 		t.Fatalf("unexpected list: %+v", list)
 	}
 
@@ -145,12 +145,12 @@ func TestAccountsAPI(t *testing.T) {
 	rec = httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 	json.NewDecoder(rec.Body).Decode(&list)
-	if len(list) != 1 || list[0].Name != "cg" {
+	if len(list) != 1 || list[0].Name != "new" {
 		t.Fatalf("after delete: %+v", list)
 	}
 
 	got, _ := mgr.Get(context.Background(), list[0].ID)
-	if got.Name != "cg" {
+	if got.Name != "new" {
 		t.Fatalf("manager not updated: %+v", got)
 	}
 }

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -15,7 +15,6 @@
   <form id="apiKeyForm">
     <input name="name" placeholder="Name" required>
     <input name="api_key" placeholder="API Key" required>
-    <input name="priority" type="number" value="0">
     <button type="submit">Add</button>
   </form>
 
@@ -23,7 +22,6 @@
   <form id="chatgptForm">
     <input name="name" placeholder="Name" required>
     <input name="refresh_token" placeholder="Refresh Token" required>
-    <input name="priority" type="number" value="0">
     <button type="submit">Add</button>
   </form>
   <button id="importBtn">Import auth.json</button>
@@ -41,15 +39,22 @@
 
 </main>
 <script>
+let accountsCache = [];
 async function loadAccounts() {
   try {
     const res = await fetch('/admin/api/accounts');
     const accounts = await res.json();
+    accountsCache = accounts;
     const tbody = document.querySelector('#accounts tbody');
     tbody.innerHTML = '';
     const shorten = s => s ? (s.length > 10 ? s.slice(0,10) + '...' : s) : '';
     accounts.forEach(a => {
       const tr = document.createElement('tr');
+      tr.draggable = true;
+      tr.dataset.id = a.id;
+      tr.addEventListener('dragstart', dragStart);
+      tr.addEventListener('dragover', dragOver);
+      tr.addEventListener('drop', drop);
       const type = a.type === 0 ? 'API Key' : 'ChatGPT';
       const id = a.account_id || a.id;
       tr.innerHTML = `<td>${id}</td><td>${type}</td><td>${a.name}</td><td>${shorten(a.api_key)}</td><td>${shorten(a.refresh_token)}</td><td>${shorten(a.access_token)}</td><td>${a.priority}</td>`;
@@ -82,8 +87,7 @@ document.getElementById('apiKeyForm').onsubmit = async (e) => {
       body: JSON.stringify({
         type: 'api_key',
         name: f.get('name'),
-        api_key: f.get('api_key'),
-        priority: Number(f.get('priority') || 0)
+        api_key: f.get('api_key')
       })
     });
     if (!resp.ok) {
@@ -106,8 +110,7 @@ document.getElementById('chatgptForm').onsubmit = async (e) => {
       body: JSON.stringify({
         type: 'chatgpt',
         name: f.get('name'),
-        refresh_token: f.get('refresh_token'),
-        priority: Number(f.get('priority') || 0)
+        refresh_token: f.get('refresh_token')
       })
     });
     if (!resp.ok) {
@@ -124,13 +127,45 @@ document.getElementById('importBtn').onclick = async () => {
   try {
     const resp = await fetch('/admin/api/accounts/import', {method: 'POST'});
     if (!resp.ok) {
-      console.error('Import auth.json failed', resp.status);
+      alert('Import auth.json failed: ' + (await resp.text()));
     }
   } catch (e) {
     console.error('Import auth.json error', e);
   }
   loadAccounts();
 };
+
+let dragged;
+function dragStart(e){
+  dragged = this;
+  e.dataTransfer.effectAllowed = 'move';
+}
+function dragOver(e){
+  e.preventDefault();
+}
+function drop(e){
+  e.preventDefault();
+  if(dragged !== this){
+    const tbody = this.parentNode;
+    tbody.insertBefore(dragged, this);
+    saveOrder();
+  }
+}
+async function saveOrder(){
+  const rows = document.querySelectorAll('#accounts tbody tr');
+  for(let i=0;i<rows.length;i++){
+    const id = Number(rows[i].dataset.id);
+    const acc = accountsCache.find(a => a.id === id);
+    if(!acc) continue;
+    acc.priority = i;
+    await fetch(`/admin/api/accounts/${id}`, {
+      method:'PUT',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify(acc)
+    });
+  }
+  loadAccounts();
+}
 
 function load() {
   loadAccounts();

--- a/internal/webui/static/logs.html
+++ b/internal/webui/static/logs.html
@@ -9,6 +9,12 @@
 <main>
 <h1>Logs</h1>
 <nav><a href="index.html">Accounts</a> | <a href="logs.html">Logs</a></nav>
+<div>
+  <button id="prevPage">Prev</button>
+  <span id="pageInfo"></span>
+  <button id="nextPage">Next</button>
+  <button id="toggleRefresh">Start Auto Refresh</button>
+</div>
 <table id="logs">
   <thead>
     <tr><th>ID</th><th>Time</th><th>Account</th><th>Method</th><th>URL</th><th>Status</th><th>Error</th><th>Details</th></tr>
@@ -21,8 +27,11 @@
 </dialog>
 </main>
 <script>
+let page = 1;
+let auto = false;
+let timer;
 async function loadLogs() {
-  const res = await fetch('/admin/api/logs');
+  const res = await fetch(`/admin/api/logs?page=${page}`);
   const logs = await res.json();
   const tbody = document.querySelector('#logs tbody');
   tbody.innerHTML = '';
@@ -41,8 +50,22 @@ async function loadLogs() {
     tr.appendChild(td);
     tbody.appendChild(tr);
   });
+  document.getElementById('pageInfo').textContent = `Page ${page}`;
 }
 
+document.getElementById('prevPage').onclick = () => { if(page>1){ page--; loadLogs(); }};
+document.getElementById('nextPage').onclick = () => { page++; loadLogs(); };
+const refreshBtn = document.getElementById('toggleRefresh');
+refreshBtn.onclick = () => {
+  auto = !auto;
+  if(auto){
+    timer = setInterval(loadLogs, 5000);
+    refreshBtn.textContent = 'Stop Auto Refresh';
+  } else {
+    clearInterval(timer);
+    refreshBtn.textContent = 'Start Auto Refresh';
+  }
+};
 document.getElementById('closeModal').onclick = () => document.getElementById('logModal').close();
 loadLogs();
 </script>


### PR DESCRIPTION
## Summary
- add priority auto-assignment and drag-and-drop reordering for accounts
- show import errors and simplify account forms
- paginate and auto-refresh logs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b92aaa73048326b0b0a98f3c3f8e87