### PR TITLE
Improve log pagination and meta info

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -174,9 +174,12 @@ type RequestLog struct {
     URL        string
     ReqHeader  http.Header
     ReqBody    string
+    ReqSize    int
     RespHeader http.Header
     RespBody   string
+    RespSize   int
     Status     int
+    DurationMs int64
     Error      string
 }
 ```

--- a/internal/log/store_test.go
+++ b/internal/log/store_test.go
@@ -34,9 +34,12 @@ func TestInsertList(t *testing.T) {
 		URL:        "u1",
 		ReqHeader:  http.Header{"A": {"1"}},
 		ReqBody:    "req1",
+		ReqSize:    4,
 		RespHeader: http.Header{"X": {"1"}},
 		RespBody:   "resp1",
+		RespSize:   5,
 		Status:     200,
+		DurationMs: 10,
 	}
 	rl2 := &RequestLog{
 		Time:       now.Add(time.Second),
@@ -45,9 +48,12 @@ func TestInsertList(t *testing.T) {
 		URL:        "u2",
 		ReqHeader:  http.Header{"B": {"2"}},
 		ReqBody:    "req2",
+		ReqSize:    4,
 		RespHeader: http.Header{"Y": {"2"}},
 		RespBody:   "resp2",
+		RespSize:   5,
 		Status:     500,
+		DurationMs: 20,
 	}
 	rl3 := &RequestLog{
 		Time:       now.Add(2 * time.Second),
@@ -56,9 +62,12 @@ func TestInsertList(t *testing.T) {
 		URL:        "u3",
 		ReqHeader:  http.Header{"C": {"3"}},
 		ReqBody:    "req3",
+		ReqSize:    4,
 		RespHeader: http.Header{"Z": {"3"}},
 		RespBody:   "resp3",
+		RespSize:   5,
 		Status:     201,
+		DurationMs: 30,
 	}
 	for i, rl := range []*RequestLog{rl1, rl2, rl3} {
 		if err := s.Insert(ctx, rl); err != nil {
@@ -72,7 +81,7 @@ func TestInsertList(t *testing.T) {
 	if len(logs) != 2 || logs[0].ID <= logs[1].ID {
 		t.Fatalf("unexpected order: %+v", logs)
 	}
-	if logs[0].ReqHeader.Get("C") != "3" || logs[0].ReqBody != "req3" || logs[0].RespHeader.Get("Z") != "3" || logs[0].RespBody != "resp3" {
+	if logs[0].ReqHeader.Get("C") != "3" || logs[0].ReqBody != "req3" || logs[0].ReqSize != 4 || logs[0].RespHeader.Get("Z") != "3" || logs[0].RespBody != "resp3" || logs[0].RespSize != 5 || logs[0].DurationMs != 30 {
 		t.Fatalf("log fields not restored: %+v", logs[0])
 	}
 

--- a/internal/webui/handler_test.go
+++ b/internal/webui/handler_test.go
@@ -168,8 +168,12 @@ func TestLogsAPI(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("logs status: %d", rec.Code)
 	}
-	var logs []logpkg.RequestLog
-	if err := json.NewDecoder(rec.Body).Decode(&logs); err != nil || len(logs) != 1 || logs[0].Method != "GET" {
-		t.Fatalf("logs decode: %v %+v", err, logs)
+	var res struct {
+		Logs    []logpkg.RequestLog `json:"logs"`
+		Page    int                 `json:"page"`
+		HasMore bool                `json:"has_more"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&res); err != nil || len(res.Logs) != 1 || res.Logs[0].Method != "GET" || res.Page != 1 || res.HasMore {
+		t.Fatalf("logs decode: %v %+v", err, res)
 	}
 }

--- a/internal/webui/static/logs.html
+++ b/internal/webui/static/logs.html
@@ -30,9 +30,13 @@
 let page = 1;
 let auto = false;
 let timer;
+let hasMore = false;
 async function loadLogs() {
   const res = await fetch(`/admin/api/logs?page=${page}`);
-  const logs = await res.json();
+  const data = await res.json();
+  const logs = data.logs;
+  hasMore = data.has_more;
+  page = data.page;
   const tbody = document.querySelector('#logs tbody');
   tbody.innerHTML = '';
   logs.forEach(l => {
@@ -51,10 +55,12 @@ async function loadLogs() {
     tbody.appendChild(tr);
   });
   document.getElementById('pageInfo').textContent = `Page ${page}`;
+  document.getElementById('prevPage').disabled = page <= 1;
+  document.getElementById('nextPage').disabled = !hasMore;
 }
 
 document.getElementById('prevPage').onclick = () => { if(page>1){ page--; loadLogs(); }};
-document.getElementById('nextPage').onclick = () => { page++; loadLogs(); };
+document.getElementById('nextPage').onclick = () => { if(hasMore){ page++; loadLogs(); }};
 const refreshBtn = document.getElementById('toggleRefresh');
 refreshBtn.onclick = () => {
   auto = !auto;


### PR DESCRIPTION
## Summary
- prevent empty log pages and disable navigation when there is no more data
- record request/response sizes and duration in request logs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b92de66a388326879b52947dba2f34