### PR TITLE
Improve logging and account import naming

### DIFF
--- a/cmd/companion/main.go
+++ b/cmd/companion/main.go
@@ -10,6 +10,7 @@ import (
 
 	"codex-companion/internal/account"
 	logstore "codex-companion/internal/log"
+	"codex-companion/internal/logger"
 	"codex-companion/internal/proxy"
 	"codex-companion/internal/scheduler"
 	"codex-companion/internal/webui"
@@ -50,8 +51,9 @@ func main() {
 	if v := os.Getenv("CODEX_COMPANION_ADDR"); v != "" {
 		addr = v
 	}
-	stdlog.Printf("Starting server on %s", addr)
+	logger.Infof("Starting server on %s", addr)
 	if err := http.ListenAndServe(addr, mux); err != nil {
+		logger.Errorf("server error: %v", err)
 		stdlog.Fatal(err)
 	}
 }

--- a/internal/log/store.go
+++ b/internal/log/store.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"time"
+
+	"codex-companion/internal/logger"
 )
 
 // RequestLog records a proxied request.
@@ -35,6 +37,7 @@ type Store struct {
 func NewStore(db *sql.DB) (*Store, error) {
 	s := &Store{db: db}
 	if err := s.init(); err != nil {
+		logger.Errorf("init logs table failed: %v", err)
 		return nil, err
 	}
 	return s, nil
@@ -58,22 +61,37 @@ func (s *Store) init() error {
         error TEXT
     )`
 	_, err := s.db.Exec(query)
+	if err != nil {
+		logger.Errorf("create logs table failed: %v", err)
+	}
 	return err
 }
 
 // Insert saves a RequestLog.
 func (s *Store) Insert(ctx context.Context, rl *RequestLog) error {
-	reqHeader, _ := json.Marshal(rl.ReqHeader)
-	respHeader, _ := json.Marshal(rl.RespHeader)
-	_, err := s.db.ExecContext(ctx, `INSERT INTO logs(time, account_id, method, url, req_header, req_body, req_size, resp_header, resp_body, resp_size, status, duration_ms, error) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+	reqHeader, err := json.Marshal(rl.ReqHeader)
+	if err != nil {
+		logger.Warnf("marshal req header failed: %v", err)
+	}
+	respHeader, err := json.Marshal(rl.RespHeader)
+	if err != nil {
+		logger.Warnf("marshal resp header failed: %v", err)
+	}
+	_, err = s.db.ExecContext(ctx, `INSERT INTO logs(time, account_id, method, url, req_header, req_body, req_size, resp_header, resp_body, resp_size, status, duration_ms, error) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		rl.Time, rl.AccountID, rl.Method, rl.URL, reqHeader, rl.ReqBody, rl.ReqSize, respHeader, rl.RespBody, rl.RespSize, rl.Status, rl.DurationMs, rl.Error)
-	return err
+	if err != nil {
+		logger.Errorf("insert request log failed: %v", err)
+		return err
+	}
+	logger.Debugf("logged request account %d status %d", rl.AccountID, rl.Status)
+	return nil
 }
 
 // List returns latest logs limited by n with offset.
 func (s *Store) List(ctx context.Context, n, offset int) ([]*RequestLog, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, time, account_id, method, url, req_header, req_body, req_size, resp_header, resp_body, resp_size, status, duration_ms, error FROM logs ORDER BY id DESC LIMIT ? OFFSET ?`, n, offset)
 	if err != nil {
+		logger.Errorf("query logs failed: %v", err)
 		return nil, err
 	}
 	defer rows.Close()
@@ -82,11 +100,21 @@ func (s *Store) List(ctx context.Context, n, offset int) ([]*RequestLog, error) 
 		var rl RequestLog
 		var reqHeader, respHeader []byte
 		if err := rows.Scan(&rl.ID, &rl.Time, &rl.AccountID, &rl.Method, &rl.URL, &reqHeader, &rl.ReqBody, &rl.ReqSize, &respHeader, &rl.RespBody, &rl.RespSize, &rl.Status, &rl.DurationMs, &rl.Error); err != nil {
+			logger.Errorf("scan log row failed: %v", err)
 			return nil, err
 		}
-		json.Unmarshal(reqHeader, &rl.ReqHeader)
-		json.Unmarshal(respHeader, &rl.RespHeader)
+		if err := json.Unmarshal(reqHeader, &rl.ReqHeader); err != nil {
+			logger.Warnf("unmarshal req header failed: %v", err)
+		}
+		if err := json.Unmarshal(respHeader, &rl.RespHeader); err != nil {
+			logger.Warnf("unmarshal resp header failed: %v", err)
+		}
 		res = append(res, &rl)
 	}
-	return res, rows.Err()
+	if err := rows.Err(); err != nil {
+		logger.Errorf("iterate logs failed: %v", err)
+		return nil, err
+	}
+	logger.Debugf("retrieved %d logs", len(res))
+	return res, nil
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -9,6 +9,7 @@ import (
 
 	"codex-companion/internal/account"
 	"codex-companion/internal/auth"
+	"codex-companion/internal/logger"
 )
 
 // Scheduler selects which account to use.
@@ -25,23 +26,29 @@ func New(mgr *account.Manager) *Scheduler {
 func (s *Scheduler) Next(ctx context.Context) (*account.Account, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	logger.Debugf("scheduler selecting next account")
 	accounts, err := s.mgr.List(ctx)
 	if err != nil {
+		logger.Errorf("list accounts failed: %v", err)
 		return nil, err
 	}
 	sort.Slice(accounts, func(i, j int) bool { return accounts[i].Priority < accounts[j].Priority })
 	now := time.Now()
 	for _, a := range accounts {
 		if a.Exhausted && now.Before(a.ResetAt) {
+			logger.Debugf("account %d exhausted until %v", a.ID, a.ResetAt)
 			continue
 		}
 		if a.Type == account.ChatGPTAccount {
 			if err := auth.Refresh(ctx, s.mgr, a); err != nil {
+				logger.Warnf("refresh account %d failed: %v", a.ID, err)
 				continue
 			}
 		}
+		logger.Debugf("selected account %d", a.ID)
 		return a, nil
 	}
+	logger.Warnf("no accounts available")
 	return nil, errors.New("no accounts available")
 }
 
@@ -64,17 +71,24 @@ func (s *Scheduler) StartReactivator(ctx context.Context, interval time.Duration
 func (s *Scheduler) reactivate(ctx context.Context) {
 	accounts, err := s.mgr.List(ctx)
 	if err != nil {
+		logger.Errorf("reactivate list accounts: %v", err)
 		return
 	}
 	now := time.Now()
 	for _, a := range accounts {
 		if a.Exhausted && now.After(a.ResetAt) {
-			s.mgr.Reactivate(ctx, a.ID)
+			logger.Infof("reactivating account %d", a.ID)
+			if err := s.mgr.Reactivate(ctx, a.ID); err != nil {
+				logger.Errorf("reactivate account %d failed: %v", a.ID, err)
+			}
 		}
 	}
 }
 
 // MarkExhausted marks an account as exhausted until resetAt.
 func (s *Scheduler) MarkExhausted(ctx context.Context, id int64, resetAt time.Time) {
-	s.mgr.MarkExhausted(ctx, id, resetAt)
+	logger.Warnf("marking account %d exhausted until %v", id, resetAt)
+	if err := s.mgr.MarkExhausted(ctx, id, resetAt); err != nil {
+		logger.Errorf("mark exhausted %d failed: %v", id, err)
+	}
 }


### PR DESCRIPTION
## Summary
- derive imported ChatGPT account names from account IDs
- add comprehensive error logs across proxy, account management, log storage, OAuth, and web UI handlers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b930a621b8832697dffaa226314c98