### PR TITLE
fix API key upstream paths for versioned bases

### DIFF
--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -83,6 +85,20 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if account.Type == acct.APIKeyAccount {
 			if account.BaseURL != "" {
 				base = account.BaseURL
+			}
+			if u, err := url.Parse(base); err == nil {
+				segs := strings.Split(strings.Trim(u.Path, "/"), "/")
+				if len(segs) > 0 {
+					last := segs[len(segs)-1]
+					if len(last) > 1 && last[0] == 'v' {
+						if _, err := strconv.Atoi(last[1:]); err == nil {
+							path = strings.TrimPrefix(path, "/v1")
+							if path == "" {
+								path = "/"
+							}
+						}
+					}
+				}
 			}
 			// normalize request body: store true and remove include
 			if len(body) > 0 {

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -207,3 +207,21 @@ func TestServeHTTPAccountBaseURL(t *testing.T) {
 		t.Fatalf("default upstream was called")
 	}
 }
+
+func TestServeHTTPAPIKeyBaseWithVersion(t *testing.T) {
+	h, mgr, _ := setupProxy(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v4/responses" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		io.WriteString(w, "ok")
+	})
+	h.UpstreamAPI = h.UpstreamAPI + "/v4"
+	ctx := context.Background()
+	mgr.AddAPIKey(ctx, "a", "k", "", 1)
+	req := httptest.NewRequest("GET", "http://localhost/v1/responses", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != 200 || rec.Body.String() != "ok" {
+		t.Fatalf("unexpected resp %d %s", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- strip `/v1` from request path when API key base URL already contains a version
- test API key request handling with versioned base URL

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b94f8399a08326a60f6ae2f29ecdd8